### PR TITLE
Python datasource UA screen charts generation

### DIFF
--- a/src/codeActions/utils/snippetBuildingUtils.ts
+++ b/src/codeActions/utils/snippetBuildingUtils.ts
@@ -17,7 +17,9 @@
 import {
   getAllMetricsByFeatureSet,
   getEntityMetrics,
+  getEntityMetricsMatchingDimensionsByRequiredDimensions,
   getEntityName,
+  getExtensionDatasource,
   getRelationships,
 } from "../../utils/extensionParsing";
 import {
@@ -347,9 +349,13 @@ export function getAllEntitiesListsSnippet(entityType: string, extension: Extens
  */
 export function getAllChartCardsSnippet(entityType: string, extension: ExtensionStub): string {
   const typeIdx = extension.topology.types.findIndex((type) => type.name === entityType);
-  const entityMetrics = getEntityMetrics(typeIdx, extension);
+  const extensionDatasource = getExtensionDatasource(extension);
+  const entityMetrics = extensionDatasource.length > 0 ?
+    getEntityMetrics(typeIdx, extension) :
+    getEntityMetricsMatchingDimensionsByRequiredDimensions(typeIdx, extension);
   const cards: { key: string; featureSet: string; metrics: string[] }[] = [];
 
+  // This won't work for datasources with no feature sets
   getAllMetricsByFeatureSet(extension).forEach((fs) => {
     let metrics = fs.metrics.filter((m) => entityMetrics.includes(m));
     if (metrics.length > 0) {

--- a/src/commandPalette/createDashboard.ts
+++ b/src/commandPalette/createDashboard.ts
@@ -117,7 +117,7 @@ function buildDashboard(extension: ExtensionStub, short: string = "Extension"): 
     // with a Python datasource or an unknown datasource.
     const extensionDatasource = getExtensionDatasource(extension);
     var entityMetrics: { key: string; name: string }[] = [];
-    if (extensionDatasource) {
+    if (extensionDatasource.length > 0) {
       entityMetrics = getEntityMetrics(idx, extension)
         .map(m => ({
           key: m,

--- a/src/interfaces/extensionMeta.ts
+++ b/src/interfaces/extensionMeta.ts
@@ -102,6 +102,11 @@ interface WmiSubGroup extends SubGroup {
   type?: "logfileEvent" | "metric" | "notificationEvent";
 }
 
+interface MetricDimensionStub {
+  key: string;
+  displayName?: string;
+}
+
 export interface MetricMetadata {
   key: string;
   metadata: {
@@ -109,6 +114,7 @@ export interface MetricMetadata {
     description?: string;
     unit?: string;
     tags?: string[];
+    dimensions?: MetricDimensionStub[];
   };
 }
 


### PR DESCRIPTION
# Summary 

Implements #91 - Generation of UA screen chart cards for Python datasource.

## Details

Following the original idea described in the issue #91 of relying on the `metrics:` section. The metrics are filtered down by `requiredDimensions` of the entities.

## Remarks

I've tried to make it work for dashboard overview generation as well but have not succeeded. Also might be a bug but looks like the generated chartCard keys are not added automatically to into the corresponding list in the detailsSettings.