### PR TITLE
retrieve metrics from metrics section for python

### DIFF
--- a/src/commandPalette/createAlert.ts
+++ b/src/commandPalette/createAlert.ts
@@ -21,7 +21,7 @@ import * as vscode from "vscode";
 import { MetricMetadata } from "../interfaces/extensionMeta";
 import { showMessage } from "../utils/code";
 import { CachedDataProvider } from "../utils/dataCaching";
-import { getAllMetricKeysFromDataSource } from "../utils/extensionParsing";
+import { getAllMetricKeys } from "../utils/extensionParsing";
 import { createUniqueFileName, getExtensionFilePath } from "../utils/fileSystem";
 
 export async function createAlert(cachedData: CachedDataProvider) {
@@ -35,7 +35,7 @@ export async function createAlert(cachedData: CachedDataProvider) {
   // TODO: we could ask the user if they want to create a new alert or edit an existing one?
 
   // Ask the user to select a metric
-  let metricKeys = getAllMetricKeysFromDataSource(extension);
+  let metricKeys = getAllMetricKeys(extension);
   if (metricKeys.length === 0 && extension.metrics) {
     metricKeys = extension.metrics.map((metric: MetricMetadata) => metric.key);
   }

--- a/src/utils/extensionParsing.ts
+++ b/src/utils/extensionParsing.ts
@@ -281,47 +281,39 @@ export function getMetricKeysFromEntitiesListCard(
 }
 
 /**
- * Extracts all metrics keys detected within the metrics section of the extension.yaml
+ * Extracts all metrics keys detected from the extension.yaml
  * @param extension extension.yaml serialized as object
  * @returns list of metric keys
  */
-export function getAllMetricKeysFromMetrics(extension: ExtensionStub): string[] {
-  const metrics: string[] = [];
-  const metricsSection = extension.metrics;
-  metricsSection.forEach(metric => {
-    metrics.push(metric.key);
-  });
-  return metrics;
-}
-
-/**
- * Extracts all metrics keys detected within the datasource section of the extension.yaml
- * @param extension extension.yaml serialized as object
- * @returns list of metric keys
- */
-export function getAllMetricKeysFromDataSource(extension: ExtensionStub): string[] {
+export function getAllMetricKeys(extension: ExtensionStub): string[] {
   const metrics: string[] = [];
   const datasource = getExtensionDatasource(extension);
-  datasource.forEach(group => {
-    if (group.metrics) {
-      group.metrics.forEach(metric => {
-        if (!metrics.includes(metric.key)) {
-          metrics.push(metric.key);
-        }
-      });
-    }
-    if (group.subgroups) {
-      group.subgroups.forEach(subgroup => {
-        if (subgroup.metrics.length > 0) {
-          subgroup.metrics.forEach(metric => {
-            if (!metrics.includes(metric.key)) {
-              metrics.push(metric.key);
-            }
-          });
-        }
-      });
-    }
-  });
+  if (datasource.length > 0) {
+    datasource.forEach(group => {
+      if (group.metrics) {
+        group.metrics.forEach(metric => {
+          if (!metrics.includes(metric.key)) {
+            metrics.push(metric.key);
+          }
+        });
+      }
+      if (group.subgroups) {
+        group.subgroups.forEach(subgroup => {
+          if (subgroup.metrics.length > 0) {
+            subgroup.metrics.forEach(metric => {
+              if (!metrics.includes(metric.key)) {
+                metrics.push(metric.key);
+              }
+            });
+          }
+        });
+      }
+    });
+  } else {
+      extension.metrics.forEach(metric => {
+      metrics.push(metric.key);
+    });
+  }
   return metrics;
 }
 
@@ -362,12 +354,7 @@ export function getEntityMetrics(
   excludeKeys: string[] = [],
 ) {
   const matchingMetrics: string[] = [];
-  let allMetrics: string[] = [];
-  if (extension.python) {
-    allMetrics = getAllMetricKeysFromMetrics(extension);
-  } else {
-    allMetrics = getAllMetricKeysFromDataSource(extension);
-  }
+  const allMetrics = getAllMetricKeys(extension);
   const patterns = getEntityMetricPatterns(typeIdx, extension);
   if (allMetrics.length > 0) {
     patterns.forEach(pattern => {

--- a/src/utils/extensionParsing.ts
+++ b/src/utils/extensionParsing.ts
@@ -310,7 +310,7 @@ export function getAllMetricKeys(extension: ExtensionStub): string[] {
       }
     });
   } else {
-      extension.metrics.forEach(metric => {
+    extension.metrics.forEach(metric => {
       metrics.push(metric.key);
     });
   }

--- a/src/utils/extensionParsing.ts
+++ b/src/utils/extensionParsing.ts
@@ -281,6 +281,20 @@ export function getMetricKeysFromEntitiesListCard(
 }
 
 /**
+ * Extracts all metrics keys detected within the metrics section of the extension.yaml
+ * @param extension extension.yaml serialized as object
+ * @returns list of metric keys
+ */
+export function getAllMetricKeysFromMetrics(extension: ExtensionStub): string[] {
+  const metrics: string[] = [];
+  const metricsSection = extension.metrics;
+  metricsSection.forEach(metric => {
+    metrics.push(metric.key);
+  });
+  return metrics;
+}
+
+/**
  * Extracts all metrics keys detected within the datasource section of the extension.yaml
  * @param extension extension.yaml serialized as object
  * @returns list of metric keys
@@ -348,7 +362,12 @@ export function getEntityMetrics(
   excludeKeys: string[] = [],
 ) {
   const matchingMetrics: string[] = [];
-  const allMetrics = getAllMetricKeysFromDataSource(extension);
+  let allMetrics: string[] = [];
+  if (extension.python) {
+    allMetrics = getAllMetricKeysFromMetrics(extension);
+  } else {
+    allMetrics = getAllMetricKeysFromDataSource(extension);
+  }
   const patterns = getEntityMetricPatterns(typeIdx, extension);
   if (allMetrics.length > 0) {
     patterns.forEach(pattern => {


### PR DESCRIPTION
# Summary
Implements part of https://github.com/dynatrace-extensions/dynatrace-extensions-vscode/issues/91 - pulling metrics from the metrics section of Python extension for use in the dashboard charts

# Details

Adds just one new function to extract the metrics keys from the metrics section for Python as opposed to from the datasource section. There is a check if it is a python extension in which case it uses this new function to get all metrics, otherwise it pulls from the datasource for all other types.

# Remarks
Have not looked at the rest of the UA aspects as I am not familiar with that functionality yet. Can review if this approach makes sense for the dashboard portion in the meantime.