### PR TITLE
fix var diagnostic regex

### DIFF
--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -299,7 +299,7 @@ const diagnoseVariables = async (
 
   const refVars: Array<string> = [];
   const defVars: Array<string> = [];
-  const varRegEx = /: ['"]?(var:[a-zA-z.-_]+)/gm;
+  const varRegEx = /: ['"]?(var:[a-zA-Z.\-_]+)/gm;
 
   extension.vars?.forEach(v => defVars.push(v.id));
 


### PR DESCRIPTION
previous regex didn't properly escape the `-` character as well as had an error in matching uppercase letters